### PR TITLE
Update the required league/oauth2-client version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - 7.4
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^5.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6",
+        "phpunit/phpunit": "^6.0|^7.0|^8.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "squizlabs/php_codesniffer": "~2.0"
+        "phpunit/phpunit": "^6.0",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "hubspot"
     ],
     "require": {
-        "league/oauth2-client": "^1.0"
+        "league/oauth2-client": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0|^7.0|^8.0",
+        "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^6",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/tests/src/HubSpotTest.php
+++ b/tests/src/HubSpotTest.php
@@ -4,9 +4,10 @@ namespace HelpScout\OAuth2\Client\Test;
 use GuzzleHttp\ClientInterface;
 use HelpScout\OAuth2\Client\Provider\HubSpot;
 use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
-class HubSpotTest extends \PHPUnit_Framework_TestCase
+class HubSpotTest extends TestCase
 {
     /**
      * @var HubSpot

--- a/tests/src/HubSpotTest.php
+++ b/tests/src/HubSpotTest.php
@@ -57,7 +57,7 @@ class HubSpotTest extends \PHPUnit_Framework_TestCase
 
         $url = $this->provider->getAuthorizationUrl($options);
 
-        $this->assertContains(urlencode(implode(' ', $options['scope'])), $url);
+        $this->assertContains(implode('%20', $options['scope']), $url);
     }
 
     public function testGetAuthorizationUrl()


### PR DESCRIPTION
We need to support the newer versions of the required packages so that we are using those tested on newer versions of PHP. I have also updated our Travis config so that we test on newer versions of PHP.